### PR TITLE
Update for SeeSharp 2.0.3

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/GuidedPathTracer/bin/Debug/net8.0/GuidedPathTracer.dll",
+            "program": "${workspaceFolder}/GuidedPathTracer/bin/Debug/net9.0/GuidedPathTracer.dll",
             "args": [],
             "cwd": "${workspaceFolder}/GuidedPathTracer",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
@@ -37,7 +37,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/Benchmark/bin/Debug/net8.0/Benchmark.dll",
+            "program": "${workspaceFolder}/Benchmark/bin/Debug/net9.0/Benchmark.dll",
             "args": [],
             "cwd": "${workspaceFolder}/Benchmark",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
@@ -56,7 +56,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/Viewer/bin/Debug/net8.0/Viewer.dll",
+            "program": "${workspaceFolder}/Viewer/bin/Debug/net9.0/Viewer.dll",
             "args": [],
             "cwd": "${workspaceFolder}/Viewer",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SeeSharp" Version="1.8.0" />
+    <PackageReference Include="SeeSharp" Version="2.0.3" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -2,9 +2,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\OpenPGL.NET\OpenPGL.NET.csproj" />
-    <ProjectReference Include="..\..\SeeSharp\SeeSharp\SeeSharp.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="SeeSharp" Version="1.8.0" />
+  </ItemGroup>
+  
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>

--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -7,10 +7,10 @@
   <ItemGroup>
     <PackageReference Include="SeeSharp" Version="1.8.0" />
   </ItemGroup>
-  
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/GuidedPathTracer/GuidedPathTracer.csproj
+++ b/GuidedPathTracer/GuidedPathTracer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GuidedPathTracer/GuidedPathTracer.csproj
+++ b/GuidedPathTracer/GuidedPathTracer.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SeeSharp" Version="1.8.0" />
+    <PackageReference Include="SeeSharp" Version="2.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GuidedPathTracer/PathLenLoggingPathTracer.cs
+++ b/GuidedPathTracer/PathLenLoggingPathTracer.cs
@@ -1,5 +1,6 @@
-using SeeSharp.Image;
+using SeeSharp.Images;
 using SeeSharp.Integrators;
+using SimpleImageIO;
 
 namespace GuidedPathTracer {
     public class PathLenLoggingPathTracer : PathTracer {
@@ -10,8 +11,8 @@ namespace GuidedPathTracer {
             scene.FrameBuffer.AddLayer("avglen", avgPathLenLayer);
         }
 
-        protected override void OnFinishedPath(in RadianceEstimate estimate, in PathState state) {
-            avgPathLenLayer.Splat(state.Pixel.X, state.Pixel.Y, state.Depth);
+        protected override void OnFinishedPath(RgbColor estimate, ref PathState state) {
+            avgPathLenLayer.Splat(state.Pixel, state.Depth);
         }
     }
 }

--- a/GuidedPathTracer/Program.cs
+++ b/GuidedPathTracer/Program.cs
@@ -1,7 +1,7 @@
 ﻿using SeeSharp.Experiments;
 
 SceneRegistry.AddSource("../Scenes");
-Benchmark benchmark = new(new GuidedPathTracer.Experiment(128, int.MaxValue), new() {
+Benchmark benchmark = new(new GuidedPathTracer.Experiment(128, int.MaxValue), [
     // SceneRegistry.LoadScene("HomeOffice"),
     // SceneRegistry.LoadScene("RoughGlassesIndirect", maxDepth: 10),
     // SceneRegistry.LoadScene("RoughGlasses", maxDepth: 10),
@@ -12,5 +12,5 @@ Benchmark benchmark = new(new GuidedPathTracer.Experiment(128, int.MaxValue), ne
     // SceneRegistry.LoadScene("ModernLivingRoom", maxDepth: 10),
     // SceneRegistry.LoadScene("Pool", maxDepth: 5),
     SceneRegistry.LoadScene("CornellBox", maxDepth: 5),
-}, "Results", 640, 480, SeeSharp.Image.FrameBuffer.Flags.SendToTev);
+], "Results", 640, 480, SeeSharp.Images.FrameBuffer.Flags.SendToTev);
 benchmark.Run(skipReference: false);

--- a/OpenPGL.NET.Tests/OpenPGL.NET.Tests.csproj
+++ b/OpenPGL.NET.Tests/OpenPGL.NET.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/OpenPGL.NET/OpenPGL.NET.csproj
+++ b/OpenPGL.NET/OpenPGL.NET.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/Viewer/Components/ProbeImage.razor
+++ b/Viewer/Components/ProbeImage.razor
@@ -80,9 +80,10 @@
         ProbePixelX = (int)e.OffsetX;
         ProbePixelY = (int)e.OffsetY;
 
+        var rng = new SeeSharp.Sampling.RNG(0);
         probeRay = Scene.Camera.GenerateRay(
             new Vector2(ProbePixelX, ProbePixelY),
-            new SeeSharp.Sampling.RNG(0)
+            ref rng
         ).Ray;
 
         await FindPoint();

--- a/Viewer/Components/SceneExplorer.razor.cs
+++ b/Viewer/Components/SceneExplorer.razor.cs
@@ -75,7 +75,7 @@ namespace Viewer.Components {
                 Scene.FrameBuffer = new(640, 480, "");
                 Scene.Prepare();
                 vis.Render(Scene);
-                previewImageData = Scene.FrameBuffer.Image.AsBase64Png();
+                previewImageData = Scene.FrameBuffer.Image.AsBase64();
 
                 Scene.Camera.WorldToCamera = old;
             }

--- a/Viewer/Components/TestSceneRunner.razor
+++ b/Viewer/Components/TestSceneRunner.razor
@@ -27,7 +27,7 @@
         <div style="height: 480px;">
             @if (renderResult != null) {
                 <div style="height: 580px; float: left;">
-                    <ProbeImage Scene="@(Scene)" PreviewImageBase64="@(renderResult.AsBase64Png())" OnClick="@Query"
+                    <ProbeImage Scene="@(Scene)" PreviewImageBase64="@(renderResult.AsBase64())" OnClick="@Query"
                         Width="640" Height="480"
                     />
                 </div>
@@ -35,7 +35,7 @@
 
             @if (regionVisImage != null) {
                 <div style="height: 580px; float: left;">
-                    <ProbeImage Scene="@(Scene)" PreviewImageBase64="@(regionVisImage.AsBase64Png())" OnClick="@Query"
+                    <ProbeImage Scene="@(Scene)" PreviewImageBase64="@(regionVisImage.AsBase64())" OnClick="@Query"
                         Width="640" Height="480"
                     />
                 </div>
@@ -46,10 +46,10 @@
             <div style="height: @(resolution)px;">
                 <div @onclick="UpdateProbePixel" style="float:left; width: @(resolution)px; height: @(resolution)px;">
                     <div class="probe-marker" style="left: @(ProbePixelX)px; top: @(ProbePixelY)px;"></div>
-                    <img class="probe-image" src="data:image/png;base64,@(distributionImage.AsBase64Png())"/>
+                    <img class="probe-image" src="data:image/png;base64,@(distributionImage.AsBase64())"/>
                 </div>
 
-                <img style="float: left;" src="data:image/png;base64,@(probeImage.AsBase64Png())"/>
+                <img style="float: left;" src="data:image/png;base64,@(probeImage.AsBase64())"/>
             </div>
 
             <SceneExplorer Scene="@(Scene)"

--- a/Viewer/Components/TestSceneRunner.razor.cs
+++ b/Viewer/Components/TestSceneRunner.razor.cs
@@ -8,7 +8,7 @@ using OpenPGL.NET;
 using SeeSharp.Cameras;
 using SeeSharp.Experiments;
 using SeeSharp.Geometry;
-using SeeSharp.Image;
+using SeeSharp.Images;
 using SeeSharp.Integrators.Bidir;
 using SeeSharp.Sampling;
 using SeeSharp.Shading;

--- a/Viewer/Viewer.csproj
+++ b/Viewer/Viewer.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/omnisharp.json
+++ b/omnisharp.json
@@ -53,6 +53,6 @@
     },
     "script": {
         "enableScriptNuGetReferences": true,
-        "defaultTargetFramework": "net8.0"
+        "defaultTargetFramework": "net9.0"
     }
 }


### PR DESCRIPTION
Update for SeeSharp 2.0.3 which works even with the most recent OpenPGL implementation (v0.7.1).
To use it with this new OpenPGL version RenderLibs have to be updated though.